### PR TITLE
ci: Group all ecosystem dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,27 @@
 version: 2
+
+multi-ecosystem-groups:
+  dependency:
+    schedule:
+      interval: "weekly"
+      labels: [ ]
+      target-branch: dev
+
 updates:
-  - package-ecosystem: github-actions
-    labels: []
+  - package-ecosystem: "github-actions"
+    multi-ecosystem-group: "dependency"
+    directory: "/"
+    patterns:
+      - "*"
+    
+  - package-ecosystem: "npm"
+    multi-ecosystem-group: "dependency"
+    directory: "/"
+    patterns:
+      - "*"
+    
+  - package-ecosystem: "gradle"
+    multi-ecosystem-group: "dependency"
     directory: /
-    target-branch: dev
-    schedule:
-      interval: monthly
-
-  - package-ecosystem: npm
-    labels: []
-    directory: /
-    target-branch: dev
-    schedule:
-      interval: monthly
-
-  - package-ecosystem: gradle
-    labels: []
-    directory: /
-    target-branch: dev
-    schedule:
-      interval: monthly
+    patterns:
+      - "*"


### PR DESCRIPTION
These were made before revanced-patches, do not merge it yet.